### PR TITLE
Add Git and GitHub for Beginners Workshop event

### DIFF
--- a/src/components/Sub_Components/Events.jsx
+++ b/src/components/Sub_Components/Events.jsx
@@ -75,6 +75,17 @@ const events = [
         <iframe  src="https://www.youtube.com/embed/Mfyh1jjqsfU?si=46zt2bY9khenrkPN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" class="top-0 left-0 absolute w-full h-full" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
       </div>`,
     },
+    {
+      title: "Git and GitHub for Beginners Workshop",
+      date: "Saturday September 28th, 2024",
+      time: "3:00 PM pst | 4:00 PM mst | 5:00 PM cst | 6:00 PM est",
+      link: "https://calendly.com/michaelvarnell/git-and-github-basics",
+      ISOdate: "2024-09-28T22:00:00.000Z",
+      description: `This class will cover Git and GitHub Basics. This will have an overview of how to setup and use Git with GitHub, and will also cover branching, common terminology, pull requests, issues, and other basics.The highlight of this class will be the hands-on practice of using Git and GitHub to collaborate on a example project.`,
+      cost: "10",
+      show: true,
+      youtubeEmbed: `<div class="relative pb-[56.25%] overflow-hidden"><iframe  src="https://www.youtube.com/embed/k-HrTJiyoAM?si=bAdqUk3pcVrsQ5X5" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" class="top-0 left-0 absolute w-full h-full" allowfullscreen></iframe> `,
+    }
 ]
 
 // Sort events by ISOdate


### PR DESCRIPTION
This pull request adds the "Git and GitHub for Beginners Workshop" event to the list of events. The event will cover Git and GitHub basics, including setup, branching, pull requests, and common terminology. It will also provide hands-on practice using Git and GitHub for collaboration on an example project. The event is scheduled for Saturday, September 28th, 2024, and there is a cost of $10 to attend. The event description includes a link to register and a YouTube video embed for more information.