### PR TITLE
Add 'Free MockAPI' link to Tools dropdown in navigation

### DIFF
--- a/src/Routes/Routes.js
+++ b/src/Routes/Routes.js
@@ -35,6 +35,7 @@ export const navItems = [
         type: 'dropdown',
         label: 'Tools',
         items: [
+            { to: 'https://mockapi.helpcodeit.com', label: 'Free MockAPI' },
             { to: 'https://codeproblems.michaelvarnell.com' , label: 'Practice Code Problems' },
             { to: '/data-generator', label: 'Data Generator' },
             {


### PR DESCRIPTION
This PR introduces a new link to 'Free MockAPI' in the Tools dropdown of the navigation menu, enhancing the available resources for users. The addition aims to provide easier access to mock API services directly from the application.