### PR TITLE
Comment out CSS Generators link in navigation

### DIFF
--- a/src/components/Pages/cssPages/CSSMain.jsx
+++ b/src/components/Pages/cssPages/CSSMain.jsx
@@ -27,7 +27,7 @@ const CSSNavigation = () => {
     // { to: "/CSSGrid", icon: Layers, label: "CSS Grid Layout" },
     { to: "/cssPages/CSSResponsive", icon: Zap, label: "Responsive Design with CSS" },
    { to: "/cssPages/CSSAnimationIntro", icon: Code, label: "CSS Animations" },
-   { to: "/cssPages/CSSGenerators", icon: Code, label: "CSS Generators" },
+   //{ to: "/cssPages/CSSGenerators", icon: Code, label: "CSS Generators" },
   ];
 
   return (


### PR DESCRIPTION
The CSS Generators link in the navigation has been commented out for future reference.