### PR TITLE
Remove commented-out deployment step from Node.js workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      # - name: Deploy to MAIN domain
-      #   run: npm run uploadMain
-
       - name: Build Vite app
         run: npm run build
         env:


### PR DESCRIPTION
Eliminate unnecessary commented-out code in the workflow to improve clarity and maintainability.