### PR TITLE
Comment out Free MockAPI link in navigation items

### DIFF
--- a/src/Routes/Routes.js
+++ b/src/Routes/Routes.js
@@ -39,7 +39,7 @@ export const navItems = [
         type: 'dropdown',
         label: 'Tools',
         items: [
-            { to: 'https://mockapi.helpcodeit.com', label: 'Free MockAPI' },
+            // { to: 'https://mockapi.helpcodeit.com', label: 'Free MockAPI' },
             {
                 to: 'https://codeproblems.michaelvarnell.com',
                 label: 'Practice Code Problems',


### PR DESCRIPTION
Remove the Free MockAPI link from the navigation items due to loading issues. This change addresses issue #503.